### PR TITLE
Reworking how downloads are managed, by breaking into two separate sl…

### DIFF
--- a/BattleNetPrefill/Program.cs
+++ b/BattleNetPrefill/Program.cs
@@ -7,17 +7,14 @@ namespace BattleNetPrefill
     // TODO - Tech Debt - Cleanup trim/single file warnings
     // TODO - Tech Debt - Dotnet 7 - See if AOT improvements help performance
     // TODO - Documentation - Document where + what is stored in the /cache dir
+    // TODO - Documentation - Update documentation to show why you should be using UTF16.  Include an image showing before/after.  Also possibly do a check on startup?
+    // TODO - Documentation - Add battle.net slow download to known issues page ? https://lancache.net/docs/common-issues/
     // TODO - Resolve issues on Github issues
     // TODO - Allocations - https://github.com/bretcope/PerformanceTypes
-    // TODO - Allocations - https://mgravell.github.io/PooledAwait/
+    // TODO - Metrics - Setup and configure Github historical statistics (Downloads, page views, etc).  https://github.com/jgehrcke/github-repo-stats
+    // TODO - General - Promote this app on r/lanparty and discord
     // TODO - Spectre - Once pull request has been merged into Spectre, remove reference to forked copy of the project
     // TODO - Spectre - Documentation on website needs to be updated to include changes
-    // TODO - General - Write check to see if a newer version is available, and display a message to the user if there is
-    // TODO - Documentation - Update documentation to show why you should be using UTF16.  Include an image showing before/after.  Also possibly do a check on startup?
-    // TODO - Metrics - Setup and configure Github historical statistics (Downloads, page views, etc).  This will be useful for seeing project usage.
-    // TODO - General - Promote this app on r/lanparty and discord
-    // TODO - Document in readme where users can find help with this project
-    // TODO - Update lancache documentation, and add battle.net slow download speeds to the list of known issues
     public static class Program
     {
         public static async Task<int> Main()

--- a/BattleNetPrefill/Properties/launchSettings.json
+++ b/BattleNetPrefill/Properties/launchSettings.json
@@ -12,6 +12,10 @@
       "commandName": "Project",
       "commandLineArgs": "prefill -p lazr --force"
     },
+    "Prefill Hearthstone": {
+      "commandName": "Project",
+      "commandLineArgs": "prefill -p hsb --force"
+    },
     "Prefill Overwatch": {
       "commandName": "Project",
       "commandLineArgs": "prefill -p pro --force"
@@ -19,6 +23,10 @@
     "Prefill WOW": {
       "commandName": "Project",
       "commandLineArgs": "prefill -p wow --force"
+    },
+    "Prefill WOW Classic": {
+      "commandName": "Project",
+      "commandLineArgs": "prefill -p wow_classic --force"
     },
     "Prefill All": {
       "commandName": "Project",

--- a/BattleNetPrefill/Utils/Extensions.cs
+++ b/BattleNetPrefill/Utils/Extensions.cs
@@ -134,7 +134,6 @@ namespace BattleNetPrefill.Utils
                                                      Prefix = FileSizePrefix.Decimal,
                                                      DisplayBits = true
                                                  });
-            spectreProgress.RefreshRate = TimeSpan.FromMilliseconds(150);
             return spectreProgress;
         }
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ By default, **BattleNetPrefill** will keep track of the most recently prefilled 
 
 Running with the flag `--force` will override this behavior, and instead will always run the prefill, re-downloading all files for the specified product.  This flag may be useful for diagnostics, or benchmarking network performance.
 
+# Need Help?
+If you are running into any issues, feel free to open up a Github issue on this repository.
+
+You can also find us on the **LanCache.NET** Discord (https://discord.com/invite/BKnBS4u), in the `#battlenet-prefill` channel.
+
 # Other Docs
 * [Development Configuration](/docs/Development.md)
 


### PR DESCRIPTION
…ices depending on request size.  Previously, small downloads were choking out the # of concurrent downloads, and reducing overall throughput