### PR TITLE
Fix timer requires line in docs

### DIFF
--- a/docs/mkdocs/install-guides/Scheduled-Job.md
+++ b/docs/mkdocs/install-guides/Scheduled-Job.md
@@ -13,7 +13,7 @@ You should create a new file named `/etc/systemd/system/{{prefillName.lower()}}.
 ```ini
 [Unit]
 Description={{prefillName}} run daily
-Requires={{prefillName}}.service
+Requires={{prefillName.lower()}}.service
 
 [Timer]
 # Runs every day at 4am (local time)


### PR DESCRIPTION
Fixing the "`Requires`" line in the timer in the docs example, since we are creating the service in the next section in lowercase, it should also be lowercase in the timer